### PR TITLE
Ignore .idea, .DS_Store and remove duplicated property in AppSettings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# Terraform artefacts:
+# Terraform artifacts:
 terraform/terraform.tfstate*
 terraform/.terraform*
 terraform/*.tfvars
@@ -9,23 +9,23 @@ deploy/values_override*.yaml
 # Skaffold config
 deploy/skaffold.yaml
 
-# Load testing artefacts
+# Load testing artifacts
 load-testing/settings.py
 load-testing/brokerservice/protobuf/broker_pb2_grpc.py
 load-testing/brokerservice/protobuf/broker_pb2.py
 
-# Java artefacts
+# Java artifacts
 apps/broker/target/**
 apps/broker/dependency-reduced-pom.xml
 connector/target/**
 connector/dependency-reduced-pom.xml
 
-# Python artefacts
+# Python artifacts
 .pytest_cache
 __pycache__
 *.pyc
 
-# Redis artefacts
+# Redis artifacts
 dump.rdb
 
 # Secrets
@@ -35,3 +35,11 @@ client_secret*.json
 *.key
 *.csr
 *.pem
+
+# Ignore .DS_Store (folder metadata file in OS X)
+*.DS_Store
+
+# Ignore IDE specific files
+.idea
+*.iml
+

--- a/apps/broker/pom.xml
+++ b/apps/broker/pom.xml
@@ -85,6 +85,7 @@ limitations under the License.
         <maven.assembly.plugin.version>3.1.1</maven.assembly.plugin.version>
         <maven.os.plugin.version>1.6.1</maven.os.plugin.version>
         <maven.protobuf.plugin.version>0.5.1</maven.protobuf.plugin.version>
+        <maven.javadoc.plugin.version>3.1.0</maven.javadoc.plugin.version>
     </properties>
 
     <profiles>
@@ -123,6 +124,7 @@ limitations under the License.
                     </plugin>
                     <plugin>
                         <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>${maven.javadoc.plugin.version}</version>
                         <configuration>
                             <additionalOptions>-Xdoclint:none</additionalOptions>
                             <javadocExecutable>${java.home}/bin/javadoc</javadocExecutable>
@@ -269,3 +271,4 @@ limitations under the License.
         </plugins>
     </build>
 </project>
+

--- a/apps/broker/src/main/java/com/google/cloud/broker/settings/AppSettings.java
+++ b/apps/broker/src/main/java/com/google/cloud/broker/settings/AppSettings.java
@@ -38,9 +38,6 @@ public class AppSettings extends Properties {
         // Path to the broker Oauth client ID for user login
         this.setProperty("CLIENT_SECRET_PATH", "/secrets/client_secret.json");
 
-        // Path to the broker Oauth client ID for user login
-        this.setProperty("CLIENT_SECRET_PATH", "/secrets/client_secret.json");
-
         // Path to the TLS private key
         this.setProperty("TLS_KEY_PATH", "/secrets/tls.pem");
 


### PR DESCRIPTION
Summary:

1. Ignore IntelliJ and macOS related temp files.
2. Set maven.javadoc plugin version. The project was showing an error on my local at least. I have set the version to the latest one available.
3. `client_secret.json` property was duplicated in AppSettings.