### PR TITLE
Closes #15: Remove unused broker_realm and origin_realm references

### DIFF
--- a/apps/broker/src/main/java/com/google/cloud/broker/settings/AppSettings.java
+++ b/apps/broker/src/main/java/com/google/cloud/broker/settings/AppSettings.java
@@ -50,9 +50,6 @@ public class AppSettings extends Properties {
         // Broker principal's host
         this.setProperty("BROKER_SERVICE_HOSTNAME", "");
 
-        // Broker's Kerberos realm
-        this.setProperty("BROKER_REALM", "BROKER");
-
         // Base level for logging
         this.setProperty("LOGGING_LEVEL", "INFO");
 

--- a/terraform/broker.tf
+++ b/terraform/broker.tf
@@ -256,8 +256,6 @@ broker:
       GCP_PROJECT: '${var.gcp_project}'
       GCP_REGION: '${var.gcp_region}'
       PROXY_USER_WHITELIST: 'hive/test-cluster-m.${var.gcp_zone}.c.${var.gcp_project}.internal@${local.dataproc_realm}'
-      BROKER_REALM: '${var.origin_realm}'
-      ORIGIN_REALM: '${var.origin_realm}'
       DOMAIN_NAME: '${var.domain}'
       BROKER_SERVICE_HOSTNAME: '${var.broker_service_hostname}'
       REDIS_CACHE_HOST: '${google_redis_instance.cache.host}'

--- a/terraform/broker.tf
+++ b/terraform/broker.tf
@@ -280,3 +280,4 @@ authorizer:
 EOT
     filename = "../deploy/values_override.yaml"
 }
+


### PR DESCRIPTION
Can someone verify whether these are the only unused references of the two variables in question.