### PR TITLE
improve configuration of broker principal and hostname

### DIFF
--- a/apps/core/pom.xml
+++ b/apps/core/pom.xml
@@ -46,6 +46,11 @@ limitations under the License.
         <artifactId>jackson-databind</artifactId>
         <version>${jackson.databind.version}</version>
       </dependency>
+      <dependency>
+        <groupId>com.typesafe</groupId>
+        <artifactId>config</artifactId>
+        <version>${config.version}</version>
+      </dependency>
     </dependencies>
 
 </project>

--- a/apps/core/src/main/java/com/google/cloud/broker/authentication/backends/KerberosUtil.java
+++ b/apps/core/src/main/java/com/google/cloud/broker/authentication/backends/KerberosUtil.java
@@ -1,0 +1,100 @@
+package com.google.cloud.broker.authentication.backends;
+
+import javax.security.auth.Subject;
+import javax.security.auth.login.AppConfigurationEntry;
+import javax.security.auth.login.Configuration;
+import javax.security.auth.login.LoginContext;
+import javax.security.auth.login.LoginException;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+public class KerberosUtil {
+
+    /**
+     *
+     * @param keytabsPath path of directory containing keytab files
+     * @return
+     */
+    public static ArrayList<Subject> loadKeytabs(File keytabsPath, Set<String> serviceNames, Set<String> hostnames, Set<String> realms) {
+        ArrayList<Subject> logins = new ArrayList<>();
+        File[] keytabFiles = keytabsPath.listFiles();
+
+        if (keytabFiles == null) {
+            throw new IllegalStateException("Invalid path `" + keytabsPath + "` as defined in the `KEYTABS_PATH` setting");
+        }
+
+        if (keytabFiles.length > 0) {
+            // Loop through the found files
+            for (File keytabFile : keytabFiles) {
+                if (keytabFile.isFile()) {
+                    sun.security.krb5.internal.ktab.KeyTab keytab = sun.security.krb5.internal.ktab.KeyTab.getInstance(keytabFile);
+                    sun.security.krb5.internal.ktab.KeyTabEntry[] entries = keytab.getEntries();
+
+                    if (keytab.isValid() && entries.length > 0) {
+                        // Perform further validation of entries in the keytab
+                        for (sun.security.krb5.internal.ktab.KeyTabEntry entry : entries) {
+                            String[] nameStrings = entry.getService().getNameStrings();
+
+                            // Ensure that the entries' service name and hostname match the whitelisted values
+                            String serviceName = nameStrings[0];
+                            String hostname = nameStrings[1];
+                            String realm = entry.getService().getRealmAsString();
+                            if (!serviceNames.contains(serviceName)) {
+                                throw new IllegalStateException(String.format("Invalid service name in keytab: %s", keytabFile.getPath()));
+                            }
+                            if (!hostnames.contains(hostname)) {
+                                throw new IllegalStateException(String.format("Invalid hostname in keytab: %s", keytabFile.getPath()));
+                            }
+                            if (!realms.contains(realm)){
+                                throw new IllegalStateException(String.format("Invalid realm in keytab: %s", keytabFile.getPath()));
+                            }
+
+                            String principal = serviceName + "/" + hostname + "@" + realm;
+                            Subject subject = login(principal, keytabFile);
+                            System.out.println("Logged in as " + principal + " from " + keytabFile.getAbsolutePath());
+                            logins.add(subject);
+                        }
+                    }
+                }
+            }
+        }
+
+        return logins;
+    }
+
+    private static Subject login(String principal, File keytabFile) {
+        try {
+            LoginContext loginContext = new LoginContext(
+                    "", new Subject(), null, getConfiguration(principal, keytabFile));
+            loginContext.login();
+            Subject subject = loginContext.getSubject();
+            return subject;
+        } catch (LoginException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static Configuration getConfiguration(String principal, File keytabFile) {
+        return new Configuration() {
+            @Override
+            public AppConfigurationEntry[] getAppConfigurationEntry(String name) {
+                Map<String, String> options = new HashMap<String, String>();
+                options.put("principal", principal);
+                options.put("keyTab", keytabFile.getPath());
+                options.put("doNotPrompt", "true");
+                options.put("useKeyTab", "true");
+                options.put("storeKey", "true");
+                options.put("isInitiator", "false");
+                return new AppConfigurationEntry[] {
+                        new AppConfigurationEntry(
+                                "com.sun.security.auth.module.Krb5LoginModule",
+                                AppConfigurationEntry.LoginModuleControlFlag.REQUIRED, options)
+                };
+            }
+        };
+    }
+
+}

--- a/apps/core/src/main/java/com/google/cloud/broker/settings/AppSettings.java
+++ b/apps/core/src/main/java/com/google/cloud/broker/settings/AppSettings.java
@@ -12,6 +12,8 @@
 package com.google.cloud.broker.settings;
 
 import com.google.cloud.broker.utils.EnvUtils;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
 
 import java.util.Map;
 import java.util.Properties;
@@ -22,6 +24,10 @@ public class AppSettings {
     private static Properties instance = null;
 
     public AppSettings() {}
+
+    public static Config getConfig() {
+        return ConfigFactory.parseProperties(getInstance());
+    }
 
     private static void loadEnvironmentSettings() {
         // Override default settings with potential environment variables

--- a/apps/core/src/test/java/com/google/cloud/broker/authentication/backends/SpnegoAuthenticatorTest.java
+++ b/apps/core/src/test/java/com/google/cloud/broker/authentication/backends/SpnegoAuthenticatorTest.java
@@ -1,0 +1,26 @@
+package com.google.cloud.broker.authentication.backends;
+
+import com.google.cloud.broker.settings.AppSettings;
+import com.google.common.collect.ImmutableSet;
+import com.typesafe.config.Config;
+import org.junit.Test;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Set;
+
+public class SpnegoAuthenticatorTest {
+
+    @Test
+    public void test() {
+        AppSettings.reset();
+        AppSettings.setProperty(SpnegoAuthenticator.BROKER_SERVICE_NAME,"broker,tb");
+        AppSettings.setProperty(SpnegoAuthenticator.BROKER_SERVICE_HOSTNAME,"lb.example.com,localhost");
+        Config config = AppSettings.getConfig();
+        Set<String> serviceNames = ImmutableSet.copyOf(config.getString(SpnegoAuthenticator.BROKER_SERVICE_NAME).split(","));
+        Set<String> hostNames = ImmutableSet.copyOf(config.getString(SpnegoAuthenticator.BROKER_SERVICE_HOSTNAME).split(","));
+        assertTrue(serviceNames.contains("broker"));
+        assertTrue(serviceNames.contains("tb"));
+        assertTrue(hostNames.contains("lb.example.com"));
+        assertTrue(hostNames.contains("localhost"));
+    }
+}

--- a/connector/src/main/java/com/google/cloud/broker/hadoop/fs/BrokerGateway.java
+++ b/connector/src/main/java/com/google/cloud/broker/hadoop/fs/BrokerGateway.java
@@ -11,10 +11,7 @@
 
 package com.google.cloud.broker.hadoop.fs;
 
-import java.security.AccessController;
-import java.security.Principal;
-import javax.security.auth.Subject;
-
+import com.google.api.client.http.GenericUrl;
 import com.google.common.io.BaseEncoding;
 import org.ietf.jgss.GSSException;
 
@@ -42,10 +39,11 @@ public final class BrokerGateway {
         this.config = config;
 
         brokerPrincipal = config.get("gcp.token.broker.principal", "");
-
-        String brokerHostname = config.get("gcp.token.broker.uri.hostname", "localhost");
-        int brokerPort = config.getInt("gcp.token.broker.uri.port", 443);
-        boolean tlsEnabled = config.getBoolean("gcp.token.broker.tls.enabled", true);
+        String brokerUri = config.get("gcp.token.broker.uri", "https://localhost:443");
+        GenericUrl url = new GenericUrl(brokerUri);
+        String brokerHostname = url.getHost();
+        int brokerPort = url.getPort();
+        boolean tlsEnabled = url.getScheme().equalsIgnoreCase("https");
         String tlsCertificate = config.get("gcp.token.broker.tls.certificate", "");
 
         managedChannel = GrpcUtils.newManagedChannel(brokerHostname, brokerPort, tlsEnabled, tlsCertificate);

--- a/connector/src/main/java/com/google/cloud/broker/hadoop/fs/SpnegoUtils.java
+++ b/connector/src/main/java/com/google/cloud/broker/hadoop/fs/SpnegoUtils.java
@@ -18,17 +18,35 @@ public final class SpnegoUtils {
     private static final String SPNEGO_OID = "1.3.6.1.5.5.2";
     private static final String KRB5_MECHANISM_OID = "1.2.840.113554.1.2.2";
     private static final String KRB5_PRINCIPAL_NAME_OID = "1.2.840.113554.1.2.2.1";
+    private static final Oid SPNEGO = mkOid(SPNEGO_OID);
+    private static final Oid KRB5_MECH = mkOid(KRB5_MECHANISM_OID);
+    private static final Oid KRB5_PRIN = mkOid(KRB5_PRINCIPAL_NAME_OID);
+    private static Oid mkOid(String oid) {
+        try {
+            return new Oid(oid);
+        } catch (GSSException e) {
+            throw new RuntimeException(e);
+        }
+    }
 
-    public static byte[] newSPNEGOToken(String brokerServiceName, String brokerHostname, String brokerRealm) throws GSSException {
+    public static byte[] newSPNEGOToken(String serviceName, String hostname, String realm) throws GSSException {
+        String servicePrincipal = serviceName + "/" + hostname + "@" + realm;
+        return newSPNEGOToken(servicePrincipal);
+    }
+
+    /**
+     *
+     * @param principal service/host.domain.tld@REALM
+     * @return
+     * @throws GSSException
+     */
+    public static byte[] newSPNEGOToken(String principal) throws GSSException {
         // Create GSS context for the broker service and the logged-in user
-        Oid krb5Mechanism = new Oid(KRB5_MECHANISM_OID);
-        Oid krb5PrincipalNameType = new Oid(KRB5_PRINCIPAL_NAME_OID);
-        Oid spnegoOid = new Oid(SPNEGO_OID);
         GSSManager manager = GSSManager.getInstance();
-        String servicePrincipal = brokerServiceName + "/" + brokerHostname + "@" + brokerRealm;
-        GSSName gssServerName = manager.createName(servicePrincipal , krb5PrincipalNameType, krb5Mechanism);
+
+        GSSName gssServerName = manager.createName(principal, KRB5_PRIN, KRB5_MECH);
         GSSContext gssContext = manager.createContext(
-            gssServerName, spnegoOid, null, GSSCredential.DEFAULT_LIFETIME);
+            gssServerName, SPNEGO, null, GSSCredential.DEFAULT_LIFETIME);
         gssContext.requestMutualAuth(true);
         gssContext.requestCredDeleg(true);
 

--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,7 @@ limitations under the License.
         <logback.version>1.2.3</logback.version>
         <logback.contrib.version>0.1.5</logback.contrib.version>
         <jackson.databind.version>2.9.9.3</jackson.databind.version>
+        <config.version>1.3.4</config.version>
         <expiringmap.version>0.5.9</expiringmap.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>


### PR DESCRIPTION
Changes in this CL:
1. allow users to configure the broker to use multiple principals from a combination of service names, hostnames and realms.
2. allow users to configure connector with broker principal decoupled from hostname.

## Connector (client) config
`gcp.token.broker.principal` indicates which principal to obtain a ticket for (principal which broker service is running as)
`gcp.token.broker.uri` indicates the full URI of the broker service and replaces `gcp.token.broker.uri.hostname` and `gcp.token.broker.uri.port` which have been removed

## Broker (server) config
`BROKER_SERVICE_NAME` allowed service names (default: `broker`)
`BROKER_SERVICE_HOSTNAME` allowed hostnames
`BROKER_SERVICE_REALM` allowed realms
These three keys restrict principals selected from among those available in keytabs found in keytab path. Any principals matching all three whitelists will be loaded and used to respond to requests.