### PR TITLE
Update providers.md that Credential Access Boundary only supports GCS buckets

### DIFF
--- a/docs/concepts/providers.md
+++ b/docs/concepts/providers.md
@@ -147,6 +147,8 @@ In the Hadoop use case, Hadoop systematically passes the target bucket to the br
 the broker connector relay the target bucket to the broker service and apply CAB on the returned access token, set
 the `gcp.token.broker.access.boundary.enabled` property to `true`.
 
+Note: Currently only GCS buckets are the only GCP resource supported by this feature.
+
 Note: To use CAB with a Cloud Storage bucket, you must set [Uniform bucket-level access](https://cloud.google.com/storage/docs/uniform-bucket-level-access)
 on the bucket. Otherwise, you'll receive the error `The operation requires that Uniform Bucket Level Access be enabled`
 when you try to access the bucket with the returned access token. To set uniform bucket-level access, you can run this

--- a/docs/concepts/providers.md
+++ b/docs/concepts/providers.md
@@ -135,7 +135,7 @@ tokens for those users, although only for the specified API scopes.
 
 ## Access boundary
 
-The broker can restrict the scope of an access token to a specific resource (e.g. a GCS bucket) by applying a
+The broker can restrict the scope of an access token to a specific resource (namely, a GCS bucket) by applying a
 [Credential Access Boundary](https://cloud.google.com/iam/docs/restricting-short-lived-credentials) (CAB) on the tokens
 that are returned by the providers. To enable this feature, the client can pass a `target` attribute when it sends a
 request to the broker.

--- a/docs/concepts/providers.md
+++ b/docs/concepts/providers.md
@@ -147,7 +147,7 @@ In the Hadoop use case, Hadoop systematically passes the target bucket to the br
 the broker connector relay the target bucket to the broker service and apply CAB on the returned access token, set
 the `gcp.token.broker.access.boundary.enabled` property to `true`.
 
-Note: Currently only GCS buckets are the only GCP resource supported by this feature.
+Note: Currently GCS bucket is the only GCP resource supported by this feature.
 
 Note: To use CAB with a Cloud Storage bucket, you must set [Uniform bucket-level access](https://cloud.google.com/storage/docs/uniform-bucket-level-access)
 on the bucket. Otherwise, you'll receive the error `The operation requires that Uniform Bucket Level Access be enabled`


### PR DESCRIPTION
Credential Access Boundaries currently only supports GCS: https://cloud.google.com/iam/docs/downscoping-short-lived-credentials#how-it-works.

The way it's currently implemented (https://github.com/GoogleCloudPlatform/gcp-token-broker/blob/06444c32706a875dd1933fa631c6d7a471e4aa6b/code/broker-server/src/main/java/com/google/cloud/broker/apps/brokerserver/accesstokens/AccessBoundaryUtils.java#L56), it only supports `availableResource`, which only works on buckets. For objects `availabilityCondition`s would be required: https://cloud.google.com/iam/docs/downscoping-short-lived-credentials#example-object-startswith.